### PR TITLE
using Microsoft.Xaml.Behaviors.Wpf instad of reference to Blend SDK

### DIFF
--- a/WaveDotNet.Designer/Views/Tree/ConnectionHandlesControl.xaml
+++ b/WaveDotNet.Designer/Views/Tree/ConnectionHandlesControl.xaml
@@ -5,7 +5,7 @@
 	xmlns:c="clr-namespace:WaveDotNet.Designer.Views.Converters"
 	xmlns:controls="clr-namespace:WaveDotNet.Designer.Views.Tree.Controls"
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-	xmlns:i="clr-namespace:System.Windows.Interactivity;assembly=System.Windows.Interactivity"
+	xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
 	xmlns:local="clr-namespace:WaveDotNet.Designer.Views.Tree"
 	xmlns:m="clr-namespace:WaveDotNet.Designer.Views.Markups"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/WaveDotNet.Designer/Views/Tree/NodeControl.xaml
+++ b/WaveDotNet.Designer/Views/Tree/NodeControl.xaml
@@ -8,7 +8,7 @@
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	xmlns:filters="clr-namespace:WaveDotNet.Designer.ViewModels.Waves.Blocks.Filters"
 	xmlns:generators="clr-namespace:WaveDotNet.Designer.ViewModels.Waves.Blocks.Generators"
-	xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+	xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
 	xmlns:local="clr-namespace:WaveDotNet.Designer.Views.Tree"
 	xmlns:m="clr-namespace:WaveDotNet.Designer.Views.Markups"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/WaveDotNet.Designer/Views/Tree/TreeControl.xaml
+++ b/WaveDotNet.Designer/Views/Tree/TreeControl.xaml
@@ -5,7 +5,7 @@
 	xmlns:c="clr-namespace:WaveDotNet.Designer.Views.Converters"
 	xmlns:controls="clr-namespace:WaveDotNet.Designer.Views.Tree.Controls"
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-	xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+	xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
 	xmlns:local="clr-namespace:WaveDotNet.Designer.Views.Tree"
 	xmlns:m="clr-namespace:WaveDotNet.Designer.Views.Markups"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/WaveDotNet.Designer/WaveDotNet.Designer.csproj
+++ b/WaveDotNet.Designer/WaveDotNet.Designer.csproj
@@ -44,6 +44,9 @@
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=3.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.3.0.0-preview3.19153.1\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Xaml.Behaviors, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.19\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
+    </Reference>
     <Reference Include="NAudio, Version=1.9.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\NAudio.1.9.0-preview2\lib\net35\NAudio.dll</HintPath>
     </Reference>

--- a/WaveDotNet.Designer/packages.config
+++ b/WaveDotNet.Designer/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="Microsoft.Extensions.DependencyInjection" version="3.0.0-preview3.19153.1" targetFramework="net461" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="3.0.0-preview3.19153.1" targetFramework="net461" />
+  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.19" targetFramework="net471" />
   <package id="NAudio" version="1.9.0-preview2" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net471" />
   <package id="System.Buffers" version="4.4.0" targetFramework="net471" />


### PR DESCRIPTION
This changes to using the Microsoft.Xaml.Behaviors.Wpf nuget package instead of using System.Windows.Interactivity from the Blend SDK.
The Blend SDK is not anymore provided in the installer of the latest Visual Studio 2019 and is now maintained in an official nuget package.
More information here: https://devblogs.microsoft.com/dotnet/open-sourcing-xaml-behaviors-for-wpf/